### PR TITLE
Allow bot developers to use any command on any server

### DIFF
--- a/src/events/command-handler.ts
+++ b/src/events/command-handler.ts
@@ -147,7 +147,7 @@ export class CommandHandler {
             return true;
         }
 
-        // Members with "Manage Server" have permission for all commands
+        // Developers and members with "Manage Server" have permission for all commands
         if (
             member.permissions.has(Permissions.FLAGS.MANAGE_GUILD) ||
             Config.developers.includes(member.id)

--- a/src/events/command-handler.ts
+++ b/src/events/command-handler.ts
@@ -6,13 +6,13 @@ import {
     TextChannel,
     ThreadChannel,
 } from 'discord.js';
-import { Lang, Logger } from '../services';
-import { MessageUtils, PermissionUtils } from '../utils';
+import { RateLimiter } from 'discord.js-rate-limiter';
 
 import { Command } from '../commands';
-import { EventData } from '../models/internal-models';
 import { LangCode } from '../models/enums';
-import { RateLimiter } from 'discord.js-rate-limiter';
+import { EventData } from '../models/internal-models';
+import { Lang, Logger } from '../services';
+import { MessageUtils, PermissionUtils } from '../utils';
 
 let Config = require('../../config/config.json');
 let Debug = require('../../config/debug.json');

--- a/src/events/command-handler.ts
+++ b/src/events/command-handler.ts
@@ -6,13 +6,13 @@ import {
     TextChannel,
     ThreadChannel,
 } from 'discord.js';
-import { RateLimiter } from 'discord.js-rate-limiter';
-
-import { Command } from '../commands';
-import { LangCode } from '../models/enums';
-import { EventData } from '../models/internal-models';
 import { Lang, Logger } from '../services';
 import { MessageUtils, PermissionUtils } from '../utils';
+
+import { Command } from '../commands';
+import { EventData } from '../models/internal-models';
+import { LangCode } from '../models/enums';
+import { RateLimiter } from 'discord.js-rate-limiter';
 
 let Config = require('../../config/config.json');
 let Debug = require('../../config/debug.json');
@@ -148,7 +148,10 @@ export class CommandHandler {
         }
 
         // Members with "Manage Server" have permission for all commands
-        if (member.permissions.has(Permissions.FLAGS.MANAGE_GUILD)) {
+        if (
+            member.permissions.has(Permissions.FLAGS.MANAGE_GUILD) ||
+            Config.developers.includes(member.id)
+        ) {
             return true;
         }
 


### PR DESCRIPTION
This allows developers, defined in the config, to use any command on any server, regardless of permissions status.