### PR TITLE
create sendEphemeral() function

### DIFF
--- a/src/utils/interaction-utils.ts
+++ b/src/utils/interaction-utils.ts
@@ -101,6 +101,34 @@ export class InteractionUtils {
             }
         }
     }
+    
+      public static async sendEphemeral(
+    intr: CommandInteraction | MessageComponentInteraction | ModalSubmitInteraction,
+    content: string | EmbedBuilder | InteractionReplyOptions,
+  ): Promise<Message> {
+    try {
+      let options: InteractionReplyOptions =
+        typeof content === 'string' ? { content } : content instanceof EmbedBuilder ? { embeds: [content] } : content;
+      if (intr.deferred || intr.replied) {
+        return await intr.followUp({
+          ...options,
+          ephemeral: true,
+        });
+      } else {
+        return await intr.reply({
+          ...options,
+          ephemeral: true,
+          fetchReply: true,
+        });
+      }
+    } catch (error) {
+      if (error instanceof DiscordAPIError && typeof error.code == 'number' && IGNORED_ERRORS.includes(error.code)) {
+        return;
+      } else {
+        throw error;
+      }
+    }
+  }
 
     public static async respond(
         intr: AutocompleteInteraction,


### PR DESCRIPTION
Allows the user to send a command ephemerally. Note that for this to work correctly, the command deferType must be set to `public deferType = CommandDeferType.HIDDEN;` at the top of command settings.

For example, if I wanted to send a hidden interaction with this utility, I'd do this in my command:
```ts
import { ChatInputCommandInteraction, PermissionsString, UserResolvable } from 'discord.js';
import { RateLimiter } from 'discord.js-rate-limiter';

import { Command, CommandDeferType } from '@/commands';
import { Language } from '@/models/enum-helpers';
import { EventData } from '@/models/internal-models';
import { Lang } from '@/services';
import { InteractionUtils } from '@/utils';

export class CreditsCommand implements Command {
  public names = [Lang.getRef('chatCommands.credits', Language.Default)];
  public cooldown = new RateLimiter(1, 5000);
  public deferType = CommandDeferType.HIDDEN; // Notice how this is HIDDEN, not the default PUBLIC.
  public requireClientPerms: PermissionsString[] = [];

  public async execute(intr: ChatInputCommandInteraction, data: EventData): Promise<void> {

    await InteractionUtils.sendEphemeral( // Note that this is not .send, but .sendEphemeral, and works just the same but hidden.
      intr,
      await Lang.getEmbed(intr.guild.id, 'displayEmbeds.credits', data.lang)
    );
  }
}
```